### PR TITLE
Merge dev-event-stream

### DIFF
--- a/android/src/main/kotlin/de/unituebingen/wearable_sensors/WearableSensorsPlugin.kt
+++ b/android/src/main/kotlin/de/unituebingen/wearable_sensors/WearableSensorsPlugin.kt
@@ -1,33 +1,77 @@
+
 package de.unituebingen.wearable_sensors
 
+import android.content.Context
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.EventChannel
 
 /** WearableSensorsPlugin */
-class WearableSensorsPlugin: FlutterPlugin, MethodCallHandler {
-  /// The MethodChannel that will the communication between Flutter and native Android
-  ///
-  /// This local reference serves to register the plugin with the Flutter Engine and unregister it
-  /// when the Flutter Engine is detached from the Activity
-  private lateinit var channel : MethodChannel
+class WearableSensorsPlugin: FlutterPlugin, EventChannel.StreamHandler, SensorEventListener {
 
-  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-    channel = MethodChannel(flutterPluginBinding.binaryMessenger, "wearable_sensors")
-    channel.setMethodCallHandler(this)
-  }
+    // Define the channel name, must match the one in Dart
+    private val EVENT_CHANNEL_NAME = "wearable_sensors"
 
-  override fun onMethodCall(call: MethodCall, result: Result) {
-    if (call.method == "getPlatformVersion") {
-      result.success("Android ${android.os.Build.VERSION.RELEASE}")
-    } else {
-      result.notImplemented()
+    private lateinit var gyroscopeChannel: EventChannel
+
+    // Android Sensor-related variables
+    private lateinit var sensorManager: SensorManager
+    private var gyroscope: Sensor? = null
+
+    // The EventSink is the key to sending events to Flutter
+    private var eventSink: EventChannel.EventSink? = null
+
+    override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        // Get the application context
+        val context = flutterPluginBinding.applicationContext
+        
+        // Setup sensor manager
+        sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        gyroscope = sensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE)
+
+        // Setup the EventChannel
+        gyroscopeChannel = EventChannel(flutterPluginBinding.binaryMessenger, EVENT_CHANNEL_NAME)
+        gyroscopeChannel.setStreamHandler(this)
     }
-  }
 
-  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-    channel.setMethodCallHandler(null)
-  }
+    // EventChannel.StreamHandler methods
+    override fun onListen(arguments: Any?, sink: EventChannel.EventSink?) {
+        // When Flutter starts listening, start the sensor
+        eventSink = sink
+        gyroscope?.let {
+            sensorManager.registerListener(this, it, SensorManager.SENSOR_DELAY_NORMAL)
+        }
+    }
+
+    override fun onCancel(arguments: Any?) {
+        // When Flutter stops listening, stop the sensor
+        sensorManager.unregisterListener(this)
+        eventSink = null
+    }
+
+    // SensorEventListener methods
+    override fun onSensorChanged(event: SensorEvent?) {
+        if (event?.sensor?.type == Sensor.TYPE_GYROSCOPE) {
+            // Create a map to send to Flutter
+            val sensorValues = mapOf(
+                "x" to event.values[0].toDouble(),
+                "y" to event.values[1].toDouble(),
+                "z" to event.values[2].toDouble()
+            )
+            // Send the data to Flutter
+            eventSink?.success(sensorValues)
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) {
+        // Not used in this example
+    }
+
+    override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        // Clean up the channel when the plugin is detached
+        gyroscopeChannel.setStreamHandler(null)
+    }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -61,7 +61,7 @@ class _MyAppState extends State<MyApp> {
     // We also handle the message potentially returning null.
     try {
       gyroStream =
-          await _wearableSensorsPlugin.getGyroscope() ?? Stream.empty();
+          await _wearableSensorsPlugin.getSensorStream(MySensorType.gyroscope) ?? Stream.empty();
     } on PlatformException {
       gyroStream = Stream.empty();
     }
@@ -88,7 +88,7 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center, // Center content vertically
             children: [
-              Text('Hello: $_platformVersion'),
+              Text('Ily: $_platformVersion'),
               // 2. Use a StreamBuilder to listen to the stream and display the number.
               StreamBuilder<int>(
                 stream: numberGenerator,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,7 +88,7 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center, // Center content vertically
             children: [
-              Text('Hello: $_platformVersion\n'),
+              Text('Hello: $_platformVersion'),
               // 2. Use a StreamBuilder to listen to the stream and display the number.
               StreamBuilder<int>(
                 stream: numberGenerator,
@@ -122,8 +122,11 @@ class _MyAppState extends State<MyApp> {
                     return Text('Error: ${snapshot.error}');
                   } else if (snapshot.hasData) {
                     // When data is available, display it in a Text widget.
+                    var x = snapshot.data?["x"]?.toStringAsFixed(9);
+                    var y = snapshot.data?["y"]?.toStringAsFixed(9);
+                    var z = snapshot.data?["z"]?.toStringAsFixed(9);
                     return Text(
-                      'Stream: ${snapshot.data}',
+                      'Gyro: \n x: $x \n y: $y \n z: $z',
                       //style: Theme.of(context).textTheme.headlineMedium,
                     );
                   } else {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,7 +63,7 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center, // Center content vertically
             children: [
-              Text('Hello world: $_platformVersion\n'),
+              Text('Hello: $_platformVersion\n'),
               // 2. Use a StreamBuilder to listen to the stream and display the number.
               StreamBuilder<int>(
                 stream: numberGenerator,
@@ -78,7 +78,7 @@ class _MyAppState extends State<MyApp> {
                     // When data is available, display it in a Text widget.
                     return Text(
                       'Counting: ${snapshot.data}',
-                      style: Theme.of(context).textTheme.headlineMedium,
+                      //style: Theme.of(context).textTheme.headlineMedium,
                     );
                   } else {
                     // Fallback for any other state.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,7 +88,7 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center, // Center content vertically
             children: [
-              Text('Ily: $_platformVersion'),
+              Text('henlo: $_platformVersion'),
               // 2. Use a StreamBuilder to listen to the stream and display the number.
               StreamBuilder<int>(
                 stream: numberGenerator,

--- a/lib/wearable_sensors.dart
+++ b/lib/wearable_sensors.dart
@@ -5,4 +5,8 @@ class WearableSensors {
   Future<String?> getPlatformVersion() {
     return WearableSensorsPlatform.instance.getPlatformVersion();
   }
+
+  Future<Stream<Map<String, double>>?> getGyroscope() {
+    return WearableSensorsPlatform.instance.getGyroscope();
+  }
 }

--- a/lib/wearable_sensors.dart
+++ b/lib/wearable_sensors.dart
@@ -1,12 +1,14 @@
 
 import 'wearable_sensors_platform_interface.dart';
 
+enum MySensorType {gyroscope, accelerometer}
+
 class WearableSensors {
   Future<String?> getPlatformVersion() {
     return WearableSensorsPlatform.instance.getPlatformVersion();
   }
 
-  Future<Stream<Map<String, double>>?> getGyroscope() {
-    return WearableSensorsPlatform.instance.getGyroscope();
+  Future<Stream<Map<String, double>>?> getSensorStream(MySensorType mySensorType) {
+    return WearableSensorsPlatform.instance.getSensorStream(mySensorType);
   }
 }

--- a/lib/wearable_sensors_event_channel.dart
+++ b/lib/wearable_sensors_event_channel.dart
@@ -20,7 +20,7 @@ class EventChannelWearableSensors extends WearableSensorsPlatform {
   Future<Stream<Map<String, double>>> getSensorStream(MySensorType mySensorType) async {
     //final version = await methodChannel.invokeMethod<String>('getPlatformVersion');
     var gyroscopeStream = eventChannel
-            .receiveBroadcastStream(mySensorType)
+            .receiveBroadcastStream(mySensorType.name)
             .map((dynamic event) => Map<String, double>.from(event));
 
   //   Stream<Map<String, double>> get accelerometerEvents {

--- a/lib/wearable_sensors_event_channel.dart
+++ b/lib/wearable_sensors_event_channel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:wearable_sensors/wearable_sensors.dart';
 
 import 'wearable_sensors_platform_interface.dart';
 
@@ -16,10 +17,10 @@ class EventChannelWearableSensors extends WearableSensorsPlatform {
   }
 
   @override
-  Future<Stream<Map<String, double>>> getGyroscope() async {
+  Future<Stream<Map<String, double>>> getSensorStream(MySensorType mySensorType) async {
     //final version = await methodChannel.invokeMethod<String>('getPlatformVersion');
     var gyroscopeStream = eventChannel
-            .receiveBroadcastStream()
+            .receiveBroadcastStream(mySensorType)
             .map((dynamic event) => Map<String, double>.from(event));
 
   //   Stream<Map<String, double>> get accelerometerEvents {

--- a/lib/wearable_sensors_event_channel.dart
+++ b/lib/wearable_sensors_event_channel.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
+
+import 'wearable_sensors_platform_interface.dart';
+
+/// An implementation of [WearableSensorsPlatform] that uses event channels.
+class EventChannelWearableSensors extends WearableSensorsPlatform {
+  /// The event channel used to interact with the native platform.
+  //@visibleForTesting
+  final eventChannel = const EventChannel('wearable_sensors');
+
+  @override
+  Future<String?> getPlatformVersion() async {
+    final version = "hello this is a version";
+    return version;
+  }
+}

--- a/lib/wearable_sensors_event_channel.dart
+++ b/lib/wearable_sensors_event_channel.dart
@@ -14,4 +14,21 @@ class EventChannelWearableSensors extends WearableSensorsPlatform {
     final version = "hello this is a version";
     return version;
   }
+
+  @override
+  Future<Stream<Map<String, double>>> getGyroscope() async {
+    //final version = await methodChannel.invokeMethod<String>('getPlatformVersion');
+    var gyroscopeStream = eventChannel
+            .receiveBroadcastStream()
+            .map((dynamic event) => Map<String, double>.from(event));
+
+  //   Stream<Map<String, double>> get accelerometerEvents {
+  //   _accelerometerStream ??= _accelerometerChannel
+  //       .receiveBroadcastStream()
+  //       .map((dynamic event) => Map<String, double>.from(event));
+  //   return _accelerometerStream!;
+  // }
+
+    return gyroscopeStream;
+  }
 }

--- a/lib/wearable_sensors_platform_interface.dart
+++ b/lib/wearable_sensors_platform_interface.dart
@@ -1,6 +1,7 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 import 'wearable_sensors_method_channel.dart';
+import 'wearable_sensors_event_channel.dart';
 
 abstract class WearableSensorsPlatform extends PlatformInterface {
   /// Constructs a WearableSensorsPlatform.
@@ -8,7 +9,9 @@ abstract class WearableSensorsPlatform extends PlatformInterface {
 
   static final Object _token = Object();
 
-  static WearableSensorsPlatform _instance = MethodChannelWearableSensors();
+  //static WearableSensorsPlatform _instance = MethodChannelWearableSensors();
+  static WearableSensorsPlatform _instance = EventChannelWearableSensors();
+
 
   /// The default instance of [WearableSensorsPlatform] to use.
   ///
@@ -26,4 +29,6 @@ abstract class WearableSensorsPlatform extends PlatformInterface {
   Future<String?> getPlatformVersion() {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
+
+  
 }

--- a/lib/wearable_sensors_platform_interface.dart
+++ b/lib/wearable_sensors_platform_interface.dart
@@ -30,5 +30,8 @@ abstract class WearableSensorsPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
+  Future<Stream<Map<String, double>>> getGyroscope(){
+    throw UnimplementedError('getGyroscope() has not been implemented');
+  }
   
 }

--- a/lib/wearable_sensors_platform_interface.dart
+++ b/lib/wearable_sensors_platform_interface.dart
@@ -1,4 +1,5 @@
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:wearable_sensors/wearable_sensors.dart';
 
 import 'wearable_sensors_method_channel.dart';
 import 'wearable_sensors_event_channel.dart';
@@ -30,8 +31,8 @@ abstract class WearableSensorsPlatform extends PlatformInterface {
     throw UnimplementedError('platformVersion() has not been implemented.');
   }
 
-  Future<Stream<Map<String, double>>> getGyroscope(){
-    throw UnimplementedError('getGyroscope() has not been implemented');
+  Future<Stream<Map<String, double>>> getSensorStream(MySensorType mySensorType){
+    throw UnimplementedError('getSensorStream(MySensorType mySensorType) has not been implemented');
   }
   
 }


### PR DESCRIPTION
**Current setup:**
- plugin has a dart side (/lib), android side (/android), and example app (/example/lib)
- dart side sets up plugin interface and event channels
- example displays stream of gyroscope events
- android side currently just one single WearableSensorsPlugin.kotlin file, sinks sensor stream
- currently sensor type is hardcoded to be gyroscope 